### PR TITLE
Add version bumping mechanism for CI/CD workflow

### DIFF
--- a/.github/actions/build-deploy/action.yml
+++ b/.github/actions/build-deploy/action.yml
@@ -23,6 +23,9 @@ inputs:
   analytics_id:
     description: 'Analytics ID'
     required: true
+  version:
+    description: 'Version'
+    required: true
 
 outputs:
   deployment_url:
@@ -58,6 +61,7 @@ runs:
         SANITY_PROJECT_ID: ${{ inputs.sanity_project_id }}
         ONESIGNAL_APPID: ${{ inputs.onesignal_appid }}
         SENTRY_DSN: ${{ inputs.sentry_dsn }}
+        VERSION: ${{ inputs.version }}
       run: bash prepare_app.sh
       shell: bash
 

--- a/.github/actions/build-deploy/action.yml
+++ b/.github/actions/build-deploy/action.yml
@@ -20,13 +20,6 @@ inputs:
   sentry_dsn:
     description: 'Sentry DSN'
     required: true
-  is_pull_request:
-    description: 'Whether this is a pull request'
-    required: true
-  pr_number:
-    description: 'Pull request number'
-    required: false
-    default: ''
   analytics_id:
     description: 'Analytics ID'
     required: true
@@ -75,7 +68,7 @@ runs:
         VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
         SANITY_PROJECT_ID: ${{ inputs.sanity_project_id }}
         SENTRY_DSN: ${{ inputs.sentry_dsn }}
-        IS_PR: ${{ inputs.is_pull_request }}
+        IS_PR: ${{ github.event_name == 'pull_request' }}
       run: |
         if [[ "$IS_PR" == "true" ]]; then
           echo "Building for pull request without --prod flag"
@@ -98,7 +91,7 @@ runs:
         VERCEL_TOKEN: ${{ inputs.vercel_token }}
         VERCEL_ORG_ID: ${{ inputs.vercel_org_id }}
         VERCEL_PROJECT_ID: ${{ inputs.vercel_project_id }}
-        IS_PR: ${{ inputs.is_pull_request }}
+        IS_PR: ${{ github.event_name == 'pull_request' }}
       run: |
         if [[ "$IS_PR" == "true" ]]; then
           echo "Deploying for pull request without --prod flag"
@@ -112,10 +105,10 @@ runs:
       shell: bash
 
     - name: Comment Pull Request with URL
-      if: inputs.is_pull_request == 'true'
+      if: github.event_name == 'pull_request'
       uses: thollander/actions-comment-pull-request@v2
       with:
         message: |
           :rocket: Deployed to Vercel Preview URL: ${{ steps.deploy.outputs.url }}
         GITHUB_TOKEN: ${{ github.token }}
-        pr_number: ${{ inputs.pr_number }} 
+        pr_number: ${{ github.event.pull_request.number }} 

--- a/.github/actions/version-bump/action.yml
+++ b/.github/actions/version-bump/action.yml
@@ -1,0 +1,69 @@
+name: 'Version Bump Action'
+description: Action that bumps the version. After merge to master it creates a new tag. For PR builds it creates a virtual version.
+inputs:
+  github_token:
+    description: 'Token to authenticate (GITHUB_TOKEN)'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Determine version and optionally create tag
+      id: determine_version
+      env:
+        GITHUB_REF: ${{ github.ref }}
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+      run: |
+        git fetch --tags
+        last_tag=$(git tag --sort=-v:refname | head -n 1)
+        if [ -z "$last_tag" ]; then
+          last_tag="1.0.0"
+        fi
+        echo "Last tag: $last_tag"
+
+        # Calculate the next version (for both PR and master)
+        bump_type="patch"
+        if [ -n "$PR_NUMBER" ]; then
+          labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' || echo "")
+          echo "Labels: $labels"
+          if echo "$labels" | grep -iq "minor"; then
+            bump_type="minor"
+          fi
+        fi
+        
+        IFS='.' read -r major minor patch <<< "$last_tag"
+        if [ "$bump_type" = "minor" ]; then
+          minor=$((minor + 1))
+          patch=0
+        else
+          patch=$((patch + 1))
+        fi
+        calculated_version="${major}.${minor}.${patch}"
+        
+        # If we are building PR (GITHUB_REF has format refs/pull/...)
+        if [[ "$GITHUB_REF" == refs/pull/* ]]; then
+          if [ -z "$PR_NUMBER" ]; then
+            echo "Failed to extract PR number, using pre0"
+            pr_number=0
+          else
+            pr_number=$PR_NUMBER
+          fi
+          new_version="${calculated_version}-pre.${pr_number}"
+          echo "Build PR: version $new_version (based on next version $calculated_version)"
+        else
+          # Build on master - use the calculated version and create tag
+          new_version="${calculated_version}"
+          echo "Merge to master: bump_type=$bump_type, new version $new_version"
+          git tag "$new_version"
+          git push origin "$new_version"
+        fi
+
+        # Save output using new method (GITHUB_OUTPUT)
+        echo "new_version=$new_version" >> $GITHUB_OUTPUT
+      shell: bash
+
+outputs:
+  new_version:
+    description: 'New version'
+    value: ${{ steps.determine_version.outputs.new_version }}

--- a/.github/workflows/release_momentum.yaml
+++ b/.github/workflows/release_momentum.yaml
@@ -34,6 +34,4 @@ jobs:
                 vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
                 vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_MOMENTUM }}
                 sentry_dsn: ${{ secrets.SENTRY_DSN_MOMENTUM }}
-                is_pull_request: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-                pr_number: ${{ github.event.pull_request.number }}
                 analytics_id: 1

--- a/.github/workflows/release_momentum.yaml
+++ b/.github/workflows/release_momentum.yaml
@@ -25,6 +25,12 @@ jobs:
                   fetch-depth: 0
                   ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || 'refs/heads/master' }}
 
+            - name: Determine version
+              id: determine_version
+              uses: ./.github/actions/version-bump
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Build and Deploy
               uses: ./.github/actions/build-deploy
               with:
@@ -34,4 +40,5 @@ jobs:
                 vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
                 vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_MOMENTUM }}
                 sentry_dsn: ${{ secrets.SENTRY_DSN_MOMENTUM }}
+                version: ${{ steps.determine_version.outputs.new_version }}
                 analytics_id: 1

--- a/.github/workflows/release_zdobywcy.yaml
+++ b/.github/workflows/release_zdobywcy.yaml
@@ -34,6 +34,4 @@ jobs:
                 vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
                 vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_ZDOBYWCY }}
                 sentry_dsn: ${{ secrets.SENTRY_DSN_ZDOBYWCY }}
-                is_pull_request: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
-                pr_number: ${{ github.event.pull_request.number }}
                 analytics_id: 2

--- a/.github/workflows/release_zdobywcy.yaml
+++ b/.github/workflows/release_zdobywcy.yaml
@@ -25,6 +25,12 @@ jobs:
                   fetch-depth: 0
                   ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || 'refs/heads/master' }}
 
+            - name: Determine version
+              id: determine_version
+              uses: ./.github/actions/version-bump
+              with:
+                github_token: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Build and Deploy
               uses: ./.github/actions/build-deploy
               with:
@@ -34,4 +40,5 @@ jobs:
                 vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
                 vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_ZDOBYWCY }}
                 sentry_dsn: ${{ secrets.SENTRY_DSN_ZDOBYWCY }}
+                version: ${{ steps.determine_version.outputs.new_version }}
                 analytics_id: 2

--- a/web/index.html
+++ b/web/index.html
@@ -26,20 +26,22 @@
     <link rel="apple-touch-icon" sizes="512x512" href="icons/Icon-512.png" />
 
     <!-- Favicon -->
-    <link rel="icon" type="image/png" href="favicon.png?v=1.0.0" />
+    <link rel="icon" type="image/png" href="favicon.png?v=%VERSION%" />
 
     <title>%TITLE%</title>
-    <link rel="manifest" href="manifest.json?v=1.0.0" />
+    <link rel="manifest" href="manifest.json?v=%VERSION%" />
 
     <!-- Matomo -->
     <script>
         var _paq = (window._paq = window._paq || []);
         _paq.push(["trackPageView"]);
         _paq.push(["enableLinkTracking"]);
+        _paq.push(['enableHeartBeatTimer']);
         (function () {
             var u = "//analytics.bkweb.dev/";
             _paq.push(["setTrackerUrl", u + "matomo.php"]);
             _paq.push(["setSiteId", "2"]);
+            _paq.push(["setCustomVariable", 1, "Version", "%VERSION%"]);
             var d = document,
                 g = d.createElement("script"),
                 s = d.getElementsByTagName("script")[0];
@@ -50,7 +52,7 @@
         })();
     </script>
     <!-- Push notification -->
-    <script src="/OneSignalSDK.page.js?v=1.0.0" defer></script>
+    <script src="/OneSignalSDK.page.js?v=%VERSION%" defer></script>
     <script>
         window.OneSignalDeferred = window.OneSignalDeferred || [];
         OneSignalDeferred.push(async function (OneSignal) {
@@ -62,7 +64,7 @@
 </head>
 
 <body>
-    <script src="flutter_bootstrap.js?v=1.0.0" async></script>
+    <script src="flutter_bootstrap.js?v=%VERSION%" async></script>
 
     <style>
         #flutter-loading-screen {


### PR DESCRIPTION
This pull request introduces a new version bump action and integrates it into the existing workflows. The changes ensure that versioning is handled automatically for both pull requests and merges to the master branch.

### Introduction of Version Bump Action:
* [`.github/actions/version-bump/action.yml`](diffhunk://#diff-5da44a99668a70753c25ffa68da622b31d152ba30f0e70fcbe28af6bc2b4af49R1-R92): Added a new action to handle version bumping. It determines the next version based on the previous tag and labels in the pull request, and creates a new tag if the build is on the master branch.

### Integration of Version Bump Action into Workflows:
* [`.github/workflows/release_momentum.yaml`](diffhunk://#diff-4d4dde0f3655acbb5d6622ee3cdd7375e5b7cd02390e564a5e64c6f4a0ab870dR28-R32): Integrated the version bump action to determine the version before the build and deploy steps, and passed the new version to the build and deploy action. [[1]](diffhunk://#diff-4d4dde0f3655acbb5d6622ee3cdd7375e5b7cd02390e564a5e64c6f4a0ab870dR28-R32) [[2]](diffhunk://#diff-4d4dde0f3655acbb5d6622ee3cdd7375e5b7cd02390e564a5e64c6f4a0ab870dR44)
* [`.github/workflows/release_zdobywcy.yaml`](diffhunk://#diff-34ea08fbcc80c2652c9818eb525f93f1983113df435fe3074ac1b8e44f9e17e4R28-R32): Similarly integrated the version bump action into the release workflow for `zdobywcy`, ensuring the new version is determined and used in the build and deploy steps. [[1]](diffhunk://#diff-34ea08fbcc80c2652c9818eb525f93f1983113df435fe3074ac1b8e44f9e17e4R28-R32) [[2]](diffhunk://#diff-34ea08fbcc80c2652c9818eb525f93f1983113df435fe3074ac1b8e44f9e17e4R44)

### Updates to Build and Deploy Action:
* [`.github/actions/build-deploy/action.yml`](diffhunk://#diff-ee1821cdf7ffb8b7adafb4c42d9137879ebdc2e540ca35177025e58293572f84R63-R72): Added steps to handle the new `version` input, ensuring the version is available during the build and deploy process.