### PR TITLE
Service worker fixes

### DIFF
--- a/.github/actions/version-bump/action.yml
+++ b/.github/actions/version-bump/action.yml
@@ -25,7 +25,7 @@ runs:
         # Calculate the next version (for both PR and master)
         bump_type="patch"
         if [ -n "$PR_NUMBER" ]; then
-          labels=$(gh pr view "$PR_NUMBER" --json labels --jq '.labels[].name' || echo "")
+          labels=$(gh pr view "$PR_NUMBER" --json labels --jq ".labels[].name" || echo "")
           echo "Labels: $labels"
           if echo "$labels" | grep -iq "minor"; then
             bump_type="minor"
@@ -38,6 +38,9 @@ runs:
           patch=0
         else
           patch=$((patch + 1))
+          if ! echo "$labels" | grep -q "patch"; then
+            gh pr edit "$PR_NUMBER" --add-label "patch"
+          fi          
         fi
         calculated_version="${major}.${minor}.${patch}"
         

--- a/web/service_worker.js
+++ b/web/service_worker.js
@@ -55,8 +55,8 @@ if (!workbox) {
             const precacheFiles = [
                 { url: '/', revision: version },
                 { url: 'index.html', revision: version },
-                { url: 'main.dart.js', revision: version },
                 { url: 'flutter_bootstrap.js', revision: version },
+                { url: 'version.json', revision: version },
                 { url: 'flutter.js', revision: version },
                 { url: 'favicon.png', revision: version },
                 { url: 'icons/Icon-256.png', revision: version },
@@ -75,7 +75,8 @@ if (!workbox) {
                 { url: 'icons/Icon-114.png', revision: version },
                 { url: 'icons/Icon-512.png', revision: version },
                 { url: 'manifest.json', revision: version },
-                { url: 'version.json', revision: version },
+                { url: 'main.dart.wasm', revision: version },
+                { url: 'main.dart.mjs', revision: version },
                 { url: 'assets/AssetManifest.json', revision: version },
                 { url: 'assets/NOTICES', revision: version },
                 { url: 'assets/FontManifest.json', revision: version },
@@ -94,6 +95,7 @@ if (!workbox) {
                 { url: 'assets/google_fonts/Lato-Black.ttf', revision: version },
                 { url: 'assets/google_fonts/Lato-Regular.ttf', revision: version },
                 { url: 'assets/google_fonts/Lato-BoldItalic.ttf', revision: version },
+                { url: 'canvaskit/skwasm_st.js', revision: version },
                 { url: 'canvaskit/skwasm.js', revision: version },
                 { url: 'canvaskit/skwasm.js.symbols', revision: version },
                 { url: 'canvaskit/canvaskit.js.symbols', revision: version },
@@ -101,9 +103,10 @@ if (!workbox) {
                 { url: 'canvaskit/chromium/canvaskit.js.symbols', revision: version },
                 { url: 'canvaskit/chromium/canvaskit.js', revision: version },
                 { url: 'canvaskit/chromium/canvaskit.wasm', revision: version },
+                { url: 'canvaskit/skwasm_st.js.symbols', revision: version },
                 { url: 'canvaskit/canvaskit.js', revision: version },
                 { url: 'canvaskit/canvaskit.wasm', revision: version },
-                { url: 'canvaskit/skwasm.worker.js', revision: version },
+                { url: 'canvaskit/skwasm_st.wasm', revision: version },
             ];
             workbox.precaching.precacheAndRoute(precacheFiles);
         });


### PR DESCRIPTION
This pull request includes updates to the version bump action and modifications to the service worker file to update the list of pre-cached files.

Changes to version bump action:
* Updated the `jq` syntax for fetching PR labels in the `.github/actions/version-bump/action.yml` file to use double quotes instead of single quotes.
* Added a new step to add a "patch" label to the PR when the patch version is incremented.

Updates to service worker pre-cached files:
* Removed `main.dart.js` and added `version.json` to the list of pre-cached files in `web/service_worker.js`.
* Removed `version.json` and added `main.dart.wasm` and `main.dart.mjs` to the pre-cached files.
* Added `canvaskit/skwasm_st.js` and `canvaskit/skwasm_st.js.symbols` to the pre-cached files, and replaced `canvaskit/skwasm.worker.js` with `canvaskit/skwasm_st.wasm`.